### PR TITLE
stay compatible with PHP 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "require": {
         "php": ">=5.5.0",
         "jakubledl/dissect": "~1.0",
-        "doctrine/annotations": "~1.0",
+        "doctrine/annotations": "<1.3.0",
         "andrewsville/php-token-reflection": "~1.4"
     },
 


### PR DESCRIPTION
Doctrine just launched Annotations 1.3.0 which is now PHP 5.6+.
